### PR TITLE
電車の全ての便を表示するモードを追加

### DIFF
--- a/app/src/assets/main.css
+++ b/app/src/assets/main.css
@@ -40,6 +40,7 @@ h1 {
 .introvert {
   font-size: 5vw;
 }
+
 .introvert2 {
   color: #a9a9a9;
 }
@@ -104,6 +105,17 @@ table tr:nth-child(odd) {
   font-size: 17px;
   opacity: 65%;
   white-space: pre-line;
+}
+.table-JRSchedule-displayStyle select{
+  background-color: #eaf4fc;
+  border-color: transparent;
+  color: #7d2927;
+  font-weight: bolder;
+}
+.table-JRSchedule-displayStyle select option{
+  background-color: #eaf4fc;
+  color: #7d2927;
+  font-weight: bolder;
 }
 
 /*誘導*/

--- a/app/src/assets/main.css
+++ b/app/src/assets/main.css
@@ -40,7 +40,6 @@ h1 {
 .introvert {
   font-size: 5vw;
 }
-
 .introvert2 {
   color: #a9a9a9;
 }

--- a/app/src/components/ScheduleTimes.vue
+++ b/app/src/components/ScheduleTimes.vue
@@ -20,7 +20,7 @@
         <tbody>
           <tr v-for="(row, i) in schedule.schedule_bus_sist_c" :key="row">
             <td>
-              <b v-if="checkShowHH(i, schedule.schedule_bus_sist_c)">{{ row.HH }}時</b>
+              <b v-if="checkShowHH(Number(i), schedule.schedule_bus_sist_c)">{{ row.HH }}時</b>
             </td>
             <template v-if="getShowType(row) === 'normal'">
               <td>{{ showDepartureTime(row) }}</td>
@@ -51,28 +51,48 @@
             <th> 大学発 </th>
             <th></th>
             <th>愛野駅着</th>
-            <th v-if="'schedule_jr_d' in schedule">JR下り</th>
-            <th v-if="'schedule_jr_u' in schedule">JR上り</th>
+            <th v-if="'schedule_jr_d' in schedule" class="table-JRSchedule-displayStyle">
+              <label for="JRScheduleDisplayStyle">JR下り</label><br>
+              <select name="JRScheduleDisplayStyle" id="JRScheduleDisplayStyle" v-on:change="onChangeJRDScheduleDisplayStyle">
+                <option value="part">一部</option>
+                <option value="all">全て</option>
+              </select>
+            </th>
+            <th v-if="'schedule_jr_u' in schedule" class="table-JRSchedule-displayStyle">
+              <label for="JRScheduleDisplayStyle">JR上り</label><br>
+              <select name="JRScheduleDisplayStyle" id="JRScheduleDisplayStyle" v-on:change="onChangeJRUScheduleDisplayStyle">
+                <option value="part">一部</option>
+                <option value="all">全て</option>
+              </select>
+            </th>
           </tr>
         </thead>
         <tbody>
+          <tr v-if="schedule_jr_d_display_style===1 || schedule_jr_u_display_style===1">
+            <td><b>始発バス前</b></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td v-if="'schedule_jr_d' in schedule">{{ showNextJR(schedule.schedule_bus_sist_a, Number(-1), schedule.schedule_jr_d, schedule.defTransferTimeMust, false, schedule_jr_d_display_style) }}</td>
+            <td v-if="'schedule_jr_u' in schedule">{{ showNextJR(schedule.schedule_bus_sist_a, Number(-1), schedule.schedule_jr_u, schedule.defTransferTimeMust, true, schedule_jr_u_display_style) }}</td>
+          </tr>
           <tr v-for="(row, i) in schedule.schedule_bus_sist_a" :key="row">
             <td>
-              <b v-if="checkShowHH(i, schedule.schedule_bus_sist_a)">{{ row.HH }}時</b>
+              <b v-if="checkShowHH(Number(i), schedule.schedule_bus_sist_a)">{{ row.HH }}時</b>
             </td>
             <template v-if="getShowType(row) === 'normal'">
               <td>{{ showDepartureTime(row) }}</td>
               <td>→</td>
               <td>{{ showArrivalTime(row) }}</td>
-              <td v-if="'schedule_jr_d' in schedule">{{ showNextJR(row, schedule.schedule_jr_d, schedule.defTransferTimeMust, false) }}</td>
-              <td v-if="'schedule_jr_u' in schedule">{{ showNextJR(row, schedule.schedule_jr_u, schedule.defTransferTimeMust, true) }}</td>
+              <td v-if="'schedule_jr_d' in schedule">{{ showNextJR(schedule.schedule_bus_sist_a, Number(i), schedule.schedule_jr_d, schedule.defTransferTimeMust, false, schedule_jr_d_display_style) }}</td>
+              <td v-if="'schedule_jr_u' in schedule">{{ showNextJR(schedule.schedule_bus_sist_a, Number(i), schedule.schedule_jr_u, schedule.defTransferTimeMust, true, schedule_jr_u_display_style) }}</td>
             </template>
             <template v-else-if="getShowType(row) === 'piston'">
               <td>{{ showDepartureTime(row, 100) }}</td>
               <td>～</td>
               <td>{{ showArrivalTime(row) }}迄<br>ピストン運行</td>
-              <td v-if="'schedule_jr_d' in schedule">{{ showNextJR(getDepartureScheduleRow(row, 100), schedule.schedule_jr_d, row.arrival_mm, false) + "\n" + showNextJR(row, schedule.schedule_jr_d, schedule.defTransferTimeMust, false) }}</td>
-              <td v-if="'schedule_jr_u' in schedule">{{ showNextJR(getDepartureScheduleRow(row, 100), schedule.schedule_jr_u, row.arrival_mm, true) + "\n" + showNextJR(row, schedule.schedule_jr_d, schedule.defTransferTimeMust, true) }}</td>
+              <td v-if="'schedule_jr_d' in schedule" v-html="showNextJR(schedule.schedule_bus_sist_a, Number(i), schedule.schedule_jr_d, row.arrival_mm, false, schedule_jr_d_display_style) + '\n' + showNextJR(schedule.schedule_bus_sist_a, Number(i), schedule.schedule_jr_d, schedule.defTransferTimeMust, false, schedule_jr_d_display_style)"></td>
+              <td v-if="'schedule_jr_u' in schedule" v0html="showNextJR(schedule.schedule_bus_sist_a, Number(i), schedule.schedule_jr_u, row.arrival_mm, true, schedule_jr_u_display_style) + '\n' + showNextJR(schedule.schedule_bus_sist_a, Number(i), schedule.schedule_jr_d, schedule.defTransferTimeMust, true, schedule_jr_u_display_style)"></td>
             </template>
             <template v-else>
               <td></td>
@@ -92,7 +112,8 @@
 </template>
 <script lang="ts">
 import { type ScheduleRow } from "@/utils/get_schedule";
-import { defineComponent } from "vue";
+import { assert } from "console";
+import { defineComponent, ref } from "vue";
 const stationName: string[] = [
   /* 各駅の駅番号(CA**の**の部分)をindexとする */
   "　　"/*熱海*/,"函南","三島","沼津","片浜","原","東田子の浦","吉原","富士","富士川","新蒲原","蒲原","由比","興津","清水","草薙","東静岡",
@@ -108,7 +129,12 @@ function GetStationName(index: number): String{
 export default defineComponent({
   props: ["toC", "schedule"],
   setup() {
+    const 
+      scheduleJRUDisplayStyleRef = ref(0),/*2026.05 追加 0: 先発又は乗り換え時間内に発車する電車のみ表示 1:それより後の、次のバスが到着するまでの全ての電車を表示する*/
+      scheduleJRDDisplayStyleRef = ref(0);/*2026.05 追加 0: 先発又は乗り換え時間内に発車する電車のみ表示 1:それより後の、次のバスが到着するまでの全ての電車を表示する*/
     return {
+      schedule_jr_u_display_style: scheduleJRUDisplayStyleRef,
+      schedule_jr_d_display_style: scheduleJRDDisplayStyleRef,
       /*前の行と時間(HH)が同じかどうか*/
       checkShowHH(i: number, rows: ScheduleRow[]) {
         return i == 0 || rows[i - 1].HH != rows[i].HH;
@@ -172,51 +198,77 @@ export default defineComponent({
           arrival_mm: row.mm - mmBase};
         return newRow;
       },
-      /*2025.11 追加*/
+      /*2025.11 追加 26.05拡張*/
       /*バス到着時刻以降に出発するJR線の電車と行き先を返す*/
-      showNextJR(rowBus: ScheduleRow, rowArrayJR: ScheduleRow[], transferTimeMustAfter: number/*最小乗り換え所要時間*/, fUpperLine: boolean) {
+      showNextJR(rowArrayBus: ScheduleRow[], busIndex: number/*-1なら始発前とする*/, rowArrayJR: ScheduleRow[], transferTimeMustAfter: number/*最小乗り換え所要時間*/,
+      fUpperLine: boolean, displayStyle: number/*次のバス到着までの全ての電車を表示するならfalse*/) {
         let nextTrain: string = "";
         let returnText: string = "";
-        let rowBus_arrival_HH: number = rowBus.HH;
-        let rowBus_arrival_mm: number = rowBus.arrival_mm;
-        if(rowBus_arrival_mm >= 60){/*arrival_mmを「分間」として使うとき*/
-          let additionalHours = 0;
-          do{
-            additionalHours++;
-            rowBus_arrival_mm -= 60;
-          }while(rowBus_arrival_mm >= 60);
-          rowBus_arrival_HH += additionalHours;
-        }else if(rowBus.mm > rowBus_arrival_mm){/*rowBus.HHは出発時刻の時間hだがこれは到着時刻の時間h*/
-          rowBus_arrival_HH++;
-        }
-
-        for (let i = 0, transferTime = 0/*乗り換え所要時間*/; i < rowArrayJR.length; i++){
-          if (rowBus_arrival_HH < rowArrayJR[i].HH || (rowBus_arrival_HH == rowArrayJR[i].HH && (rowBus_arrival_mm) <= rowArrayJR[i].mm)){
-            /*乗り換え時間を計算*/
-            if(rowBus_arrival_HH < rowArrayJR[i].HH){
-              transferTime += 60;
-            }
-            transferTime += rowArrayJR[i].mm - rowBus_arrival_mm;
-            /*nextTrainに次の列車の時刻(と行き先)を書き込み*/
-            nextTrain = "";
-            // nextTrain = String(rowArrayJR[i].HH) + ":";デバッグ用.
-            if (rowArrayJR[i].mm < 10) {
-              nextTrain += "0"; //0詰め
-            }
-            if (fUpperLine) {/*上り線*/
-              nextTrain = nextTrain + String(rowArrayJR[i].mm) + " " + GetStationName(rowArrayJR[i].arrival_mm);
-            }else{/*下り線*/
-              nextTrain = GetStationName(rowArrayJR[i].arrival_mm) + " " + nextTrain + String(rowArrayJR[i].mm);
-            }
-            /*returnTextの最後に追加*/
-            returnText += nextTrain;
-            /*乗り換え時間が最小乗り換え時間より短い場合、恐らく乗れないため表示はするが後発も表示する(breakしない)*/
-            if(transferTime >= transferTimeMustAfter){
-              break;
-            }
-            returnText += "\n";
+        /*rowArrayBus[busIndex+1]が常にあるとは限らないのでそれとは別に使う要素だけ抜き取った配列を用意する*/
+        let nullStartBus: ScheduleRow = {
+          HH: 3,
+          mm: 59,
+          arrival_mm: 0,
+        };
+        let nullLastBus: ScheduleRow = {
+          HH: 24 + nullStartBus.HH/*終電よりあとにする必要があるため適当に100時に*/,
+          mm: nullStartBus.arrival_mm,
+          arrival_mm: nullStartBus.arrival_mm+1,/*適当な数ですが0より大、60より小である必要があります*/
+        };
+        let arrivalRows: ScheduleRow[] = [(busIndex < 0) ? {...nullStartBus} : {...rowArrayBus[busIndex]}, (busIndex+1 < rowArrayBus.length) ? {...rowArrayBus[busIndex+1]} : {...nullLastBus}];
+        for(let i = 0; i < arrivalRows.length; i++){
+          if(arrivalRows[i].arrival_mm >= 60){/*arrival_mmを「分間」として使うとき*/
+            let additionalHours = 0;
+            do{
+              additionalHours++;
+              arrivalRows[i].arrival_mm -= 60;
+            }while(arrivalRows[i].arrival_mm >= 60);
+            arrivalRows[i].HH += additionalHours;
+          }else if(arrivalRows[i].mm > arrivalRows[i].arrival_mm){/*rowBus.HHは出発時刻の時間hだがこれは到着時刻の時間h*/
+            arrivalRows[i].HH++;
           }
         }
+        // returnText += String(arrivalRows[1].HH) + ":" + String(arrivalRows[1].mm);
+        let passedTrainCount: number = 0;/*駅についてから通過した電車の数*/
+        for (let i = 0, transferTime = 0/*乗り換え所要時間*/; i < rowArrayJR.length; i++){
+          if(rowArrayJR[i].HH < arrivalRows[1].HH || (rowArrayJR[i].HH == arrivalRows[1].HH && rowArrayJR[i].mm < arrivalRows[1].arrival_mm)){
+            if (arrivalRows[0].HH < rowArrayJR[i].HH || (arrivalRows[0].HH == rowArrayJR[i].HH && arrivalRows[0].arrival_mm <= rowArrayJR[i].mm)){
+              /*乗り換え時間を計算*/
+              if(arrivalRows[0].HH < rowArrayJR[i].HH){
+                transferTime += 60;
+              }
+              transferTime += rowArrayJR[i].mm - arrivalRows[0].arrival_mm;
+              /*nextTrainに次の列車の時刻(と行き先)を書き込み*/
+              nextTrain = "";
+              /*全ての電車を表示する場合始発前と終バスのところだけ時刻部分を付加*/
+              if(1 || (displayStyle == 1 && (busIndex == -1 || busIndex+1 >= rowArrayBus.length))){
+                nextTrain = String(rowArrayJR[i].HH) + ":";
+              }
+              /*0詰め*/
+              if (rowArrayJR[i].mm < 10) {
+                nextTrain += "0";
+              }
+              if (fUpperLine) {/*上り線*/
+                nextTrain += String(rowArrayJR[i].mm) + " " + GetStationName(rowArrayJR[i].arrival_mm);
+              }else{/*下り線*/
+                nextTrain = `${GetStationName(rowArrayJR[i].arrival_mm)}${" "}${nextTrain}${String(rowArrayJR[i].mm)}`;
+              }
+              /*returnTextの最後に追加*/
+              returnText += nextTrain;
+              /*displayStyleで、乗り換え時間が最小乗り換え時間より短い場合、恐らく乗れないため表示はするが後発も表示する(breakしない)*/
+              if(displayStyle == 0 && transferTime >= transferTimeMustAfter){
+                break;
+              }
+              returnText += "\n";
+              
+              passedTrainCount++;
+            }
+          }else{
+            /*次のバスが到着した以降に来る電車は次のバスと同じ行に表示するのでbreak*/
+            break;
+          }
+        }
+
         return returnText;
       },
       /*2025.11 追加*/
@@ -224,6 +276,32 @@ export default defineComponent({
       showTableNotes() {
         return String("バス・JR線のいずれも遅延等に対応していません。\nJR線の行き先はは無印: 上り/熱海、下り/浜松 行きです。\n\
 「JR」は、JRグループ各社の登録商標です。");
+      },
+
+      /*2026.05 追加 JR線の一部/全部のプルダウン*/
+      onChangeJRDScheduleDisplayStyle(event: Event) {
+        const select = event.target as HTMLSelectElement;
+        switch(select.value){
+          default:
+          case "part":
+            scheduleJRDDisplayStyleRef.value = 0;
+            break;
+          case "all":
+            scheduleJRDDisplayStyleRef.value = 1;
+            break;
+        }
+      },
+      onChangeJRUScheduleDisplayStyle(event: Event) {
+        const select = event.target as HTMLSelectElement;
+        switch(select.value){
+          default:
+          case "part":
+            scheduleJRUDisplayStyleRef.value = 0;
+            break;
+          case "all":
+            scheduleJRUDisplayStyleRef.value = 1;
+            break;
+        }
       },
     };
   },

--- a/app/src/components/ScheduleTimes.vue
+++ b/app/src/components/ScheduleTimes.vue
@@ -240,7 +240,7 @@ export default defineComponent({
               /*nextTrainに次の列車の時刻(と行き先)を書き込み*/
               nextTrain = "";
               /*全ての電車を表示する場合始発前と終バスのところだけ時刻部分を付加*/
-              if(1 || (displayStyle == 1 && (busIndex == -1 || busIndex+1 >= rowArrayBus.length))){
+              if(displayStyle == 1 && (busIndex == -1 || busIndex+1 >= rowArrayBus.length)){
                 nextTrain = String(rowArrayJR[i].HH) + ":";
               }
               /*0詰め*/

--- a/app/src/components/ScheduleTimes.vue
+++ b/app/src/components/ScheduleTimes.vue
@@ -112,7 +112,6 @@
 </template>
 <script lang="ts">
 import { type ScheduleRow } from "@/utils/get_schedule";
-import { assert } from "console";
 import { defineComponent, ref } from "vue";
 const stationName: string[] = [
   /* 各駅の駅番号(CA**の**の部分)をindexとする */
@@ -268,7 +267,6 @@ export default defineComponent({
             break;
           }
         }
-
         return returnText;
       },
       /*2025.11 追加*/

--- a/app/src/views/index.vue
+++ b/app/src/views/index.vue
@@ -377,7 +377,6 @@ export default defineComponent({
       strokeDashoffset: strokeDashoffsetRef,
       rModal: rModalRef,
       defTransferTimeMust: defTransferTimeMustRef,
-      
       onChange() {
         // クリックイベントでイベント発火
         next = null;

--- a/app/src/views/index.vue
+++ b/app/src/views/index.vue
@@ -200,7 +200,7 @@ export default defineComponent({
       modeSubTitleRef = ref(""),
       strokeDashoffsetRef = ref(0),
       rModalRef = ref(null),
-      defTransferTimeMust = ref(5);/*2025.11 追加 既定の乗り換え所要時間*/
+      defTransferTimeMustRef = ref(5);/*2025.11 追加 既定の乗り換え所要時間*/
     const update = () => {
       //isActiveを切り替えることで再描画される。
       isActiveRef.value = ""; //一度他の値に書き換えて再描画をさせる
@@ -376,7 +376,8 @@ export default defineComponent({
       modeSubTitle: modeSubTitleRef,
       strokeDashoffset: strokeDashoffsetRef,
       rModal: rModalRef,
-      defTransferTimeMust: defTransferTimeMust,
+      defTransferTimeMust: defTransferTimeMustRef,
+      
       onChange() {
         // クリックイベントでイベント発火
         next = null;


### PR DESCRIPTION
時刻表の著作権に関して、データ自体には著作権がないという前提でサイト独自のUIを使って表示しているわけなのですが、そのうち一部のダイヤだけを表示することは著作権ではなくあたかもその間に電車が来ないかのような表示になりかねず良くないという情報を確認したため愛野駅を発着する全ての電車を表示するモードを追加しました。プルダウンを追加しただけで通常の表示は従来と同じです。

* JR上り/下り それぞれの下に [一部/全部] の プルダウンを追加(既定: 一部)  
* 全部を選択した場合、始発前と終バス部分に沢山データが入り何時なのかわからなくなるため時刻の表示を付与