### PR TITLE
axiosを廃止してFetch APIに移行

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
-        "axios": "^0.26.0",
         "twemoji": "^14.0.2",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
@@ -402,8 +401,7 @@
       "version": "18.17.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.13.tgz",
       "integrity": "sha512-SlLPDDe6YQl1JnQQy4hgsuJeo5q5c1TBU4be4jeBLXsqpjoDbfb0HesSfhMwnaxfSJ4txtfzJzW5/x/43fkkfQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.3.4",
@@ -673,14 +671,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -931,25 +921,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -2053,7 +2024,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2100,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
       "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -2155,7 +2124,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
       "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.3.4",
         "@vue/compiler-sfc": "3.3.4",

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,6 @@
   },
   "author": "s-n-1-0",
   "dependencies": {
-    "axios": "^0.26.0",
     "twemoji": "^14.0.2",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"

--- a/app/src/utils/get_schedule.ts
+++ b/app/src/utils/get_schedule.ts
@@ -2,14 +2,13 @@
  * json形式のスケジュールを取得して処理します。
  */
 
-import axios from "axios";
 /**
  * 過去のスケジュール情報をまとめたリストを取得する
  */
 export async function getYearList() {
   try {
-    const res = await axios.get("/sist_bus/json/schedules/yyyy.json");
-    return res.data;
+    const res = await fetch("/sist_bus/json/schedules/yyyy.json");
+    return await res.json();
   } catch {
     return null;
   }
@@ -40,8 +39,9 @@ export async function getScheduleJson(
       filePath += "_" + String(suffix);
     }
     filePath += ".json";
-    const res = await axios.get(filePath);
-    let json: ScheduleJson = res.data;
+    const res = await fetch(filePath);
+    if (!res.ok) throw new Error(res.statusText);
+    let json: ScheduleJson = await res.json();
     /*読み込んだ時刻表にダイヤ改正があるかを確認 (下のcheckAndFilterScheduleにも同じようなループがあるが大きな変更を避けるため据え置き)*/
     if (json.ex != null) {
       for (let idx in json.ex) {


### PR DESCRIPTION
先々月axiosにおいてサプライチェーン攻撃が発生しました。
（参考：https://yamory.io/blog/supplychain-attack-on-axios ）

当リポジトリではaxiosの利用を廃止し、ブラウザに標準搭載されているFetch APIへ移行します（元々移行予定でした）。